### PR TITLE
Allow typescript in node_modules

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -30,7 +30,7 @@ module.exports = (env, argv) => {
       rules: [
         {
           test: /\.tsx?$/,
-          use: [{loader: 'ts-loader', options: {onlyCompileBundledFiles: true}}],
+          use: [{loader: 'ts-loader', options: {onlyCompileBundledFiles: true, allowTsInNodeModules: true}}],
           exclude: /node_modules/,
         },
       ],


### PR DESCRIPTION
We need to allow building Typescript in the `node_modules`, as this is required by the `brave-core-crx-packager` which packages the Greaselion CRX.