### PR TITLE
Don't exclude node_modules when running webpack

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -31,7 +31,6 @@ module.exports = (env, argv) => {
         {
           test: /\.tsx?$/,
           use: [{loader: 'ts-loader', options: {onlyCompileBundledFiles: true, allowTsInNodeModules: true}}],
-          exclude: /node_modules/,
         },
       ],
     },


### PR DESCRIPTION
We need to allow building Typescript in the node_modules, as this is required by the brave-core-crx-packager which packages the Greaselion CRX.

Follow on to #14.