### PR TITLE
Add support for Rewards Twitter publishers

### DIFF
--- a/Greaselion.json
+++ b/Greaselion.json
@@ -1,6 +1,18 @@
 [
   {
     "urls": [
+      "https://twitter.com/*",
+      "https://*.twitter.com/*"
+    ],
+    "scripts": [
+      "scripts/brave_rewards/publisher/twitter/twitter.bundle.js"
+    ],
+    "preconditions": {
+      "twitter-tips-enabled": true
+    }
+  },
+  {
+    "urls": [
       "https://m.youtube.com/*",
       "https://www.youtube.com/*"
     ],

--- a/scripts/brave_rewards/publisher/common/types.ts
+++ b/scripts/brave_rewards/publisher/common/types.ts
@@ -1,0 +1,5 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+export const braveRewardsExtensionId = 'jidkidbbcafjabdphckchenhfomhnfma'

--- a/scripts/brave_rewards/publisher/common/utils.ts
+++ b/scripts/brave_rewards/publisher/common/utils.ts
@@ -31,3 +31,21 @@ export const extractData = (data: string, matchAfter: string, matchUntil: string
 
   return match
 }
+
+export const areObjectsEqualShallow = (firstObj: {}, secondObj: {}) => {
+  const firstObjPropertyNames = Object.getOwnPropertyNames(firstObj)
+  const secondObjPropertyNames = Object.getOwnPropertyNames(secondObj)
+
+  if (firstObjPropertyNames.length !== secondObjPropertyNames.length) {
+    return false
+  }
+
+  for (let i = 0; i < firstObjPropertyNames.length; i++) {
+    const propertyName = firstObjPropertyNames[i]
+    if (firstObj[propertyName] !== secondObj[propertyName]) {
+      return false
+    }
+  }
+
+  return true
+}

--- a/scripts/brave_rewards/publisher/twitter/auth.ts
+++ b/scripts/brave_rewards/publisher/twitter/auth.ts
@@ -1,0 +1,53 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+type SessionId = string | null
+
+const authHeaderNames = [
+  'authorization',
+  'x-csrf-token',
+  'x-guest-token'
+]
+
+const authTokenCookieRegex = /[; ]_twitter_sess=([^\s;]*)/
+
+let lastSessionId: SessionId = null
+
+let authHeaders = {}
+
+const readSessionCookie = (cookiesString: string): SessionId => {
+  if (!cookiesString) {
+    return null
+  }
+
+  const match = cookiesString.match(authTokenCookieRegex)
+  if (!match) {
+    return null
+  }
+
+  return unescape(match[1])
+}
+
+export const processRequestHeaders = (requestHeaders: any[]) => {
+  if (!requestHeaders) {
+    return {}
+  }
+
+  for (const header of requestHeaders) {
+    // Parse cookies for session id
+    if (header.name === 'Cookie') {
+      const currentSessionId = readSessionCookie(header.value as string)
+      const hasAuthChanged = (currentSessionId !== lastSessionId)
+      if (hasAuthChanged) {
+        // Clear cached auth data when session changes
+        lastSessionId = currentSessionId
+        authHeaders = {}
+      }
+    } else if (authHeaderNames.includes(header.name) || header.name.startsWith('x-twitter-')) {
+      authHeaders[header.name] = header.value
+    }
+  }
+
+  return authHeaders
+}

--- a/scripts/brave_rewards/publisher/twitter/twitter.ts
+++ b/scripts/brave_rewards/publisher/twitter/twitter.ts
@@ -1,0 +1,589 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import * as auth from './auth'
+import * as commonTypes from '../common/types'
+import * as commonUtils from '../common/utils'
+import * as types from './types'
+import * as utils from './utils'
+
+const sendHeadersUrls = [ 'https://api.twitter.com/1.1/*' ]
+const sendHeadersExtra = [ 'requestHeaders', 'extraHeaders' ]
+
+let port: chrome.runtime.Port | null = null
+
+let registeredOnSendHeadersWebRequest = false
+
+let registeredOnUpdatedTab = false
+
+let configureTipActionTimeout: any = null
+
+let credentialHeaders = {}
+
+let newTwitter = true
+
+interface MediaMetaData {
+  user: {
+    id: string
+    screenName: string
+    fullName: string
+    favIconUrl: string
+  }
+  post: {
+    id: string
+    timestamp: string
+    text: string
+  }
+}
+
+// Remove when https://github.com/brave/brave-browser/issues/11890 is resolved
+const getMessage = (id: string) => {
+  switch (id) {
+    case 'twitterTipsHoverText':
+      return 'Tip this tweet'
+    case 'twitterTipsIconLabel':
+      return 'Tip'
+  }
+
+  return ''
+}
+
+const sendAPIRequest = (name: string, url: string) => {
+  return new Promise((resolve, reject) => {
+    if (!name || !url) {
+      reject(new Error('Invalid parameters'))
+      return
+    }
+
+    if (Object.keys(credentialHeaders).length === 0) {
+      reject(new Error('Missing credential headers'))
+      return
+    }
+
+    if (!port) {
+      reject(new Error('Invalid port'))
+      return
+    }
+
+    port.postMessage({
+      type: 'OnAPIRequest',
+      mediaType: types.mediaType,
+      data: {
+        name,
+        url,
+        init: {
+          credentials: 'include',
+          headers: {
+            ...credentialHeaders
+          },
+          referrerPolicy: 'no-referrer-when-downgrade',
+          method: 'GET',
+          redirect: 'follow'
+        }
+      }})
+
+    port.onMessage.addListener(function onMessageListener(msg) {
+      if (!port) {
+        reject(new Error('Invalid port'))
+        return
+      }
+      if (!msg || !msg.data) {
+        port.onMessage.removeListener(onMessageListener)
+        reject(new Error('Invalid message'))
+        return
+      }
+      if (msg.type === 'OnAPIResponse') {
+        if (!msg.data.name || (!msg.data.response && !msg.data.error)) {
+          port.onMessage.removeListener(onMessageListener)
+          reject(new Error('Invalid message'))
+          return
+        }
+        if (msg.data.name === name) {
+          port.onMessage.removeListener(onMessageListener)
+          if (msg.data.error) {
+            reject(new Error(msg.data.error))
+            return
+          }
+          resolve(msg.data.response)
+          return
+        }
+      }
+    })
+  })
+}
+
+const getTweetDetails = async (tweetId: string) => {
+  if (!tweetId) {
+    return Promise.reject(new Error('Invalid parameters'))
+  }
+
+  const url = `https://api.twitter.com/1.1/statuses/show.json?id=${tweetId}`
+  return sendAPIRequest('GetTweetDetails', url)
+}
+
+const getUserDetails = async (screenName: string) => {
+  if (!screenName) {
+    return Promise.reject(new Error('Invalid parameters'))
+  }
+
+  const url = `https://api.twitter.com/1.1/users/show.json?screen_name=${screenName}`
+  return sendAPIRequest('GetUserDetails', url)
+}
+
+const getMediaMetaData = (tweet: Element, tweetId: string): Promise<MediaMetaData> => {
+  if (!tweet || !tweetId) {
+    return Promise.reject(new Error('Invalid parameters'))
+  }
+
+  return getTweetDetails(tweetId)
+    .then((details: any) => {
+      return {
+        user: {
+          id: details.user.id_str,
+          screenName: details.user.screen_name,
+          fullName: details.user.name,
+          favIconUrl: details.user.profile_image_url_https.replace('_normal', '')
+        },
+        post: {
+          id: tweetId,
+          timestamp: details.created_at,
+          text: details.text
+        }
+      }
+    })
+    .catch((error: any) => {
+      console.error(`Failed to fetch tweet details for ${tweetId}: ${error.message}`)
+      return Promise.reject(error)
+    })
+}
+
+const getMediaMetaDataForOldTwitter = (tweet: Element, tweetId: string): MediaMetaData | null => {
+  if (!tweet) {
+    return null
+  }
+
+  const tweetTextElements = tweet.getElementsByClassName('tweet-text')
+  if (!tweetTextElements || tweetTextElements.length === 0) {
+    return null
+  }
+
+  const tweetText = tweetTextElements[0] as HTMLElement
+
+  const tweetTimestampElements = tweet.getElementsByClassName('js-short-timestamp')
+  if (!tweetTimestampElements || tweetTimestampElements.length === 0) {
+    return null
+  }
+
+  const tweetTimestamp = tweetTimestampElements[0].getAttribute('data-time') || ''
+
+  return {
+    user: {
+      id: tweet.getAttribute('data-user-id') || '',
+      screenName: tweet.getAttribute('data-screen-name') || '',
+      fullName: tweet.getAttribute('data-name') || '',
+      favIconUrl: ''
+    },
+    post: {
+      id: tweetId,
+      timestamp: tweetTimestamp,
+      text: tweetText.innerText || ''
+    }
+  }
+}
+
+const onTipActionKey = (e: KeyboardEvent) => {
+  if (e.key !== 'Enter' && e.code !== 'Space') {
+    return
+  }
+
+  const activeItem = e.target as HTMLElement
+  if (!activeItem) {
+    return
+  }
+
+  const shadowRoot = activeItem.shadowRoot
+  if (!shadowRoot) {
+    return
+  }
+
+  const tipButton: HTMLElement | null = shadowRoot.querySelector('.js-actionButton')
+  if (tipButton) {
+    tipButton.click()
+  }
+}
+
+const isThreadParent = (tweet: Element) => {
+  if (!tweet || !location.pathname.includes('/status/')) {
+    return false
+  }
+
+  const threadParent = tweet.querySelector("a[href*='how-to-tweet']")
+  if (!threadParent) {
+    return false
+  }
+
+  return true
+}
+
+const createTipAction = (tweet: Element, tweetId: string, hasUserActions: boolean) => {
+  // Create the tip action
+  const tipAction = document.createElement('div')
+  tipAction.className = 'ProfileTweet-action js-tooltip action-brave-tip'
+  tipAction.style.display = 'inline-block'
+  tipAction.style.minWidth = '80px'
+  tipAction.style.textAlign = hasUserActions ? 'right' : 'start'
+  tipAction.setAttribute('role', 'button')
+  tipAction.setAttribute('tabindex', '0')
+  tipAction.setAttribute('data-original-title', getMessage('twitterTipsHoverText'))
+  tipAction.addEventListener('keydown', onTipActionKey)
+
+  // Create the tip button
+  const tipButton = document.createElement('button')
+  tipButton.className = 'ProfileTweet-actionButton u-textUserColorHover js-actionButton'
+  tipButton.style.background = 'transparent'
+  tipButton.style.border = '0'
+  tipButton.style.color = '#657786'
+  tipButton.style.cursor = 'pointer'
+  tipButton.style.display = 'inline-block'
+  tipButton.style.fontSize = '16px'
+  tipButton.style.lineHeight = '1'
+  tipButton.style.outline = '0'
+  tipButton.style.padding = '0 2px'
+  tipButton.style.position = 'relative'
+  tipButton.type = 'button'
+  tipButton.onclick = function (event) {
+    if (newTwitter) {
+      getMediaMetaData(tweet, tweetId)
+        .then((mediaMetaData: MediaMetaData) => {
+          if (mediaMetaData) {
+            tipUser(mediaMetaData)
+          }
+        })
+        .catch((error: any) => {
+          console.error(`Failed to fetch tweet metadata for ${tweet}:`, error)
+        })
+    } else {
+      const mediaMetaData = getMediaMetaDataForOldTwitter(tweet, tweetId)
+      if (mediaMetaData) {
+        tipUser(mediaMetaData)
+      }
+    }
+    event.stopPropagation()
+  }
+
+  // Thread parents require a slightly larger margin due to layout differences
+  if (newTwitter && tweet && isThreadParent(tweet)) {
+    tipButton.style.marginTop = '12px'
+  }
+
+  // Create the tip icon container
+  const tipIconContainer = document.createElement('div')
+  tipIconContainer.className = 'IconContainer js-tooltip'
+  tipIconContainer.style.display = 'inline-block'
+  tipIconContainer.style.lineHeight = '0'
+  tipIconContainer.style.position = 'relative'
+  tipIconContainer.style.verticalAlign = 'middle'
+  tipButton.appendChild(tipIconContainer)
+
+  // Create the tip icon
+  const tipIcon = document.createElement('span')
+  tipIcon.className = 'Icon Icon--medium'
+  tipIcon.style.background = 'transparent'
+  tipIcon.style.content = 'url(\'data:image/svg+xml;utf8,<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" viewBox="0 0 105 100" style="enable-background:new 0 0 105 100;" xml:space="preserve"><style type="text/css">.st1{fill:%23662D91;}.st2{fill:%239E1F63;}.st3{fill:%23FF5000;}.st4{fill:%23FFFFFF;stroke:%23FF5000;stroke-width:0.83;stroke-miterlimit:10;}</style><title>BAT_icon</title><g id="Layer_2_1_"><g id="Layer_1-2"><polygon class="st1" points="94.8,82.6 47.4,55.4 0,82.9 "/><polygon class="st2" points="47.4,0 47.1,55.4 94.8,82.6 "/><polygon class="st3" points="0,82.9 47.2,55.9 47.4,0 "/><polygon class="st4" points="47.1,33.7 28,66.5 66.7,66.5 "/></g></g></svg>\')'
+  tipIcon.style.display = 'inline-block'
+  tipIcon.style.fontSize = '18px'
+  tipIcon.style.fontStyle = 'normal'
+  tipIcon.style.height = '16px'
+  tipIcon.style.marginTop = '5px'
+  tipIcon.style.position = 'relative'
+  tipIcon.style.verticalAlign = 'baseline'
+  tipIcon.style.width = '16px'
+  tipIconContainer.appendChild(tipIcon)
+
+  // Create the tip action count (typically used to present a counter
+  // associated with the action, but we'll use it to display a static
+  // action label)
+  const tipActionCount = document.createElement('span')
+  tipActionCount.className = 'ProfileTweet-actionCount'
+  tipActionCount.style.color = '#657786'
+  tipActionCount.style.display = 'inline-block'
+  tipActionCount.style.fontSize = '12px'
+  tipActionCount.style.fontWeight = 'bold'
+  tipActionCount.style.lineHeight = '1'
+  tipActionCount.style.marginLeft = '6px'
+  tipActionCount.style.position = 'relative'
+  tipActionCount.style.verticalAlign = 'text-bottom'
+  tipButton.appendChild(tipActionCount)
+
+  // Create the tip action count presentation
+  const tipActionCountPresentation = document.createElement('span')
+  tipActionCountPresentation.className = 'ProfileTweet-actionCountForPresentation'
+  tipActionCountPresentation.textContent = getMessage('twitterTipsIconLabel')
+  tipActionCount.appendChild(tipActionCountPresentation)
+
+  // Create the shadow DOM root that hosts our injected DOM elements
+  const shadowRoot = tipAction.attachShadow({ mode: 'open' })
+  shadowRoot.appendChild(tipButton)
+
+  // Create style element for hover color
+  const style = document.createElement('style')
+  const css = '.ProfileTweet-actionButton :hover { color: #FB542B }'
+  style.appendChild(document.createTextNode(css))
+  shadowRoot.appendChild(style)
+
+  return tipAction
+}
+
+const configureTipAction = () => {
+  clearTimeout(configureTipActionTimeout)
+
+  // Reset page state since first run of this function may have
+  // been pre-content
+  newTwitter = true
+
+  let tweets = document.querySelectorAll('[role="article"]')
+  if (tweets.length === 0) {
+    tweets = document.querySelectorAll('.tweet')
+    newTwitter = false
+  }
+
+  for (let i = 0; i < tweets.length; ++i) {
+    const tweetId = utils.getTweetId(tweets[i], newTwitter)
+    if (!tweetId) {
+      continue
+    }
+
+    let actions
+
+    if (newTwitter) {
+      actions = tweets[i].querySelector('[role="group"]')
+    } else {
+      actions = tweets[i].querySelector('.js-actions')
+    }
+
+    if (!actions) {
+      continue
+    }
+
+    const braveTipActions = actions.getElementsByClassName('action-brave-tip')
+
+    if (braveTipActions.length === 0) {
+      const numActions = actions.querySelectorAll(':scope > div').length || 0
+      const hasUserActions = numActions > 3
+      const tipAction = createTipAction(tweets[i], tweetId, hasUserActions)
+      actions.appendChild(tipAction)
+    }
+  }
+
+  configureTipActionTimeout = setTimeout(configureTipAction, 3000)
+}
+
+const handleOnSendHeadersWebRequest = (mediaType: string, details: any) => {
+  if (mediaType !== types.mediaType || !details || !details.requestHeaders) {
+    return
+  }
+
+  const authHeaders = auth.processRequestHeaders(details.requestHeaders)
+  if (commonUtils.areObjectsEqualShallow(authHeaders, credentialHeaders)) {
+    return
+  }
+
+  credentialHeaders = authHeaders
+
+  sendPublisherInfo()
+  configureTipAction()
+}
+
+const handleOnUpdatedTab = (changeInfo: any) => {
+  if (!changeInfo || !changeInfo.url) {
+    return
+  }
+
+  sendPublisherInfo()
+}
+
+const registerOnSendHeadersWebRequest = () => {
+  if (registeredOnSendHeadersWebRequest) {
+    return
+  }
+
+  registeredOnSendHeadersWebRequest = true
+
+  if (!port) {
+    return
+  }
+
+  port.postMessage({
+    type: 'RegisterOnSendHeadersWebRequest',
+    mediaType: types.mediaType,
+    data: {
+      urlPatterns: sendHeadersUrls,
+      extra: sendHeadersExtra
+    }
+  })
+
+  port.onMessage.addListener(function (msg) {
+    if (!msg.data) {
+      return
+    }
+    switch (msg.type) {
+      case 'OnSendHeadersWebRequest': {
+        handleOnSendHeadersWebRequest(msg.mediaType, msg.data.details)
+        break
+      }
+    }
+  })
+}
+
+const registerOnUpdatedTab = () => {
+  if (registeredOnUpdatedTab) {
+    return
+  }
+
+  registeredOnUpdatedTab = true
+
+  if (!port) {
+    return
+  }
+
+  port.postMessage({
+    type: 'RegisterOnUpdatedTab',
+    mediaType: types.mediaType,
+  })
+
+  port.onMessage.addListener(function (msg) {
+    if (!msg.data) {
+      return
+    }
+    switch (msg.type) {
+      case 'OnUpdatedTab': {
+        handleOnUpdatedTab(msg.data.changeInfo)
+        break
+      }
+    }
+  })
+}
+
+const sendPublisherInfoForExcludedPage = () => {
+  const url = `https://${types.mediaDomain}`
+  const publisherKey = types.mediaDomain
+  const publisherName = types.mediaDomain
+  const mediaKey = ''
+  const favIconUrl = ''
+
+  if (!port) {
+    return
+  }
+
+  port.postMessage({
+    type: 'SavePublisherVisit',
+    mediaType: '',
+    data: {
+      url,
+      publisherKey,
+      publisherName,
+      mediaKey,
+      favIconUrl
+    }
+  })
+}
+
+const sendPublisherInfoForStandardPage = (url: URL) => {
+  const screenName = utils.getScreenNameFromUrl(url)
+  if (!screenName) {
+    return
+  }
+
+  getUserDetails(screenName)
+    .then((userDetails: any) => {
+      const userId = userDetails.id_str
+      const publisherKey = utils.buildPublisherKey(userId)
+      const publisherName = screenName
+      const mediaKey = ''
+      const favIconUrl = userDetails.profile_image_url_https.replace('_normal', '')
+
+      const profileUrl = utils.buildProfileUrl(screenName, userId)
+
+      if (!port) {
+        return
+      }
+
+      port.postMessage({
+        type: 'SavePublisherVisit',
+        mediaType: types.mediaType,
+        data: {
+          url: profileUrl,
+          publisherKey,
+          publisherName,
+          mediaKey,
+          favIconUrl
+        }
+      })
+    })
+    .catch(error => {
+      console.error(`Failed to fetch user details for ${screenName}: ${error.message}`)
+    })
+}
+
+const sendPublisherInfo = () => {
+  const url = new URL(location.href)
+  if (utils.isExcludedPath(url.pathname)) {
+    sendPublisherInfoForExcludedPage()
+  } else {
+    sendPublisherInfoForStandardPage(url)
+  }
+}
+
+const tipUser = (mediaMetaData: MediaMetaData) => {
+  if (!mediaMetaData) {
+    return
+  }
+
+  const profileUrl = utils.buildProfileUrl(mediaMetaData.user.screenName, mediaMetaData.user.id)
+  const publisherKey = utils.buildPublisherKey(mediaMetaData.user.id)
+  const publisherName = mediaMetaData.user.screenName
+
+  if (!port) {
+    return
+  }
+
+  port.postMessage({
+    type: 'TipUser',
+    mediaType: types.mediaType,
+    data: {
+      url: profileUrl,
+      publisherKey,
+      publisherName,
+      favIconUrl: mediaMetaData.user.favIconUrl,
+      postId: mediaMetaData.post.id,
+      postTimestamp: mediaMetaData.post.timestamp,
+      postText: mediaMetaData.post.text
+    }
+  })
+}
+
+const initScript = () => {
+  // Don't run in incognito context
+  if (chrome.extension.inIncognitoContext) {
+    return
+  }
+
+  port = chrome.runtime.connect(commonTypes.braveRewardsExtensionId, { name: 'Greaselion' })
+
+  // Send publisher info and configure tip action on visibility change
+  document.addEventListener('visibilitychange', function () {
+    if (document.visibilityState === 'visible') {
+      console.debug('visibilitychange event triggered')
+      sendPublisherInfo()
+      configureTipAction()
+    }
+  })
+
+  registerOnSendHeadersWebRequest()
+  registerOnUpdatedTab()
+
+  console.info('Greaselion script loaded: twitter.ts')
+}
+
+initScript()

--- a/scripts/brave_rewards/publisher/twitter/types.ts
+++ b/scripts/brave_rewards/publisher/twitter/types.ts
@@ -1,0 +1,6 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+export const mediaType = 'twitter'
+export const mediaDomain = 'twitter.com'

--- a/scripts/brave_rewards/publisher/twitter/utils.test.ts
+++ b/scripts/brave_rewards/publisher/twitter/utils.test.ts
@@ -1,0 +1,74 @@
+import * as utils from './utils'
+
+test('builds media key', () => {
+  expect(utils.buildMediaKey('user')).toBe('twitter_user')
+})
+
+test('builds publisher key', () => {
+  expect(utils.buildPublisherKey('12345')).toBe('twitter#channel:12345')
+})
+
+test('builds profile url with empty params', () => {
+  expect(utils.buildProfileUrl('', '')).toBe('')
+})
+
+test('builds profile url with screen name only', () => {
+  expect(utils.buildProfileUrl('user'))
+    .toBe('https://twitter.com/user/')
+})
+
+test('builds profile url with user id and screen name', () => {
+  expect(utils.buildProfileUrl('user', '12345'))
+    .toBe('https://twitter.com/intent/user?user_id=12345&screen_name=user')
+})
+
+test('gets publisher name from page with matching title', () => {
+  document.title = 'User (@user)'
+  expect(utils.getPublisherNameFromPage()).toBe('User')
+})
+
+test('gets publisher name from page with empty title', () => {
+  document.title = ''
+  expect(utils.getPublisherNameFromPage()).toBe('')
+})
+
+test('gets publisher name from page with non-matching title', () => {
+  document.title = 'User (user)'
+  expect(utils.getPublisherNameFromPage()).toBe('')
+})
+
+test('gets screen name from matching url', () => {
+  const url = new URL('https://www.twitter.com/user')
+  expect(utils.getScreenNameFromUrl(url)).toBe('user')
+})
+
+test('gets screen name from matching url query param', () => {
+  const url = new URL('https://www.twitter.com/foo?screen_name=user')
+  expect(utils.getScreenNameFromUrl(url)).toBe('user')
+})
+
+test('gets screen name from matching url with incorrect query param', () => {
+  const url = new URL('https://www.twitter.com/foo?bar=user')
+  expect(utils.getScreenNameFromUrl(url)).toBe('foo')
+})
+
+test('gets screen name from matching tweet url', () => {
+  const url = new URL('https://twitter.com/lukemulks/status/1293113074317049856')
+  expect(utils.getScreenNameFromUrl(url)).toBe('lukemulks')
+})
+
+test('root path is excluded', () => {
+  expect(utils.isExcludedPath('/')).toBe(true)
+})
+
+test('path is excluded', () => {
+  expect(utils.isExcludedPath('/about')).toBe(true)
+})
+
+test('path is excluded based on start match', () => {
+  expect(utils.isExcludedPath('/account/foo')).toBe(true)
+})
+
+test('path is not excluded', () => {
+  expect(utils.isExcludedPath('/foo')).toBe(false)
+})

--- a/scripts/brave_rewards/publisher/twitter/utils.ts
+++ b/scripts/brave_rewards/publisher/twitter/utils.ts
@@ -1,0 +1,128 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import * as types from './types'
+
+export const buildMediaKey = (mediaId: string) => {
+  if (!mediaId) {
+    return ''
+  }
+
+  return `${types.mediaType}_${mediaId}`
+}
+
+export const buildPublisherKey = (key: string) => {
+  if (!key) {
+    return ''
+  }
+
+  return `${types.mediaType}#channel:${key}`
+}
+
+export const buildProfileUrl = (screenName: string, userId?: string) => {
+  if (!screenName) {
+    return ''
+  }
+
+  if (userId) {
+    return `https://twitter.com/intent/user?user_id=${userId}&screen_name=${screenName}`
+  }
+
+  return `https://twitter.com/${screenName}/`
+}
+
+export const getPublisherNameFromPage = () => {
+  const components = document.title.split('(@')
+  if (!components || components.length <= 1 || components[0] === document.title) {
+    return ''
+  }
+
+  return components[0].trim()
+}
+
+export const getTweetId = (tweet: Element, isNewTwitter: boolean) => {
+  if (!tweet) {
+    return null
+  }
+
+  if (!isNewTwitter) {
+    return tweet.getAttribute('data-tweet-id')
+  }
+
+  const status = tweet.querySelector("a[href*='/status/']") as HTMLAnchorElement
+  if (!status || !status.href) {
+    return null
+  }
+
+  const tweetIdMatches = status.href.match(/status\/(\d+)/)
+  if (!tweetIdMatches || tweetIdMatches.length < 2) {
+    return null
+  }
+
+  return tweetIdMatches[1]
+}
+
+export const getScreenNameFromUrl = (url: URL) => {
+  const searchParams = new URLSearchParams(url.search)
+  if (!searchParams) {
+    return ''
+  }
+
+  const screenName = searchParams.get('screen_name')
+  if (screenName) {
+    return unescape(screenName)
+  }
+
+  if (!url.pathname) {
+    return ''
+  }
+
+  const pathComponents = url.pathname.split('/').filter(item => item)
+  if (!pathComponents || pathComponents.length === 0) {
+    return ''
+  }
+
+  return pathComponents[0]
+}
+
+export const isExcludedPath = (path: string) => {
+  const paths = [
+    '/',
+    '/about',
+    '/home',
+    '/login',
+    '/logout',
+    '/messages',
+    '/privacy',
+    '/search',
+    '/settings',
+    '/tos'
+  ]
+
+  if (paths.includes(path)) {
+    return true
+  }
+
+  const startPatterns = [
+    '/account/',
+    '/compose/',
+    '/explore',
+    '/hashtag/',
+    '/i/',
+    '/messages/',
+    '/notifications',
+    '/settings/',
+    '/who_to_follow/',
+    '/?login',
+    '/?logout',
+  ]
+
+  for (const pattern of startPatterns) {
+    if (path.startsWith(pattern)) {
+      return true
+    }
+  }
+
+  return false
+}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -13,6 +13,7 @@ module.exports = (env, argv) => {
   const config = {
     devtool: argv.mode === 'development' ? 'inline-source-map' : false,
     entry: {
+      ['scripts/brave_rewards/publisher/twitter/twitter']: './scripts/brave_rewards/publisher/twitter/twitter',
       ['scripts/brave_rewards/publisher/youtube/youtube']: './scripts/brave_rewards/publisher/youtube/youtube'
     },
     plugins: [


### PR DESCRIPTION
Associated brave-core PR: https://github.com/brave/brave-core/pull/6671

Adds support for Twitter-based publisher tips via a Greaselion script. The script reacts to URL navigations and state changes by sending the associated publisher info to the Rewards extension, allowing tips to be supported via the Rewards panel and an injected inline tip button in the user's Twitter feed.