### PR TITLE
Send favicon when visiting YouTube user pages

### DIFF
--- a/scripts/brave_rewards/publisher/youtube/youtube.ts
+++ b/scripts/brave_rewards/publisher/youtube/youtube.ts
@@ -112,6 +112,7 @@ const sendPublisherInfoForUser = () => {
 
       const publisherKey = utils.buildPublisherKey(channelId)
       const publisherName = utils.getChannelNameFromResponse(responseText)
+      const favIconUrl = utils.getFavIconUrlFromResponse(responseText)
 
       // This media key represents the channel trailer video
       let mediaKey = ''
@@ -134,7 +135,8 @@ const sendPublisherInfoForUser = () => {
           url: publisherUrl,
           publisherKey,
           publisherName,
-          mediaKey
+          mediaKey,
+          favIconUrl
         }
       })
     })


### PR DESCRIPTION
Resolves https://github.com/brave/brave-browser/issues/11883. Test plan is specified in issue.