### PR TITLE
Always fetch custom urls

### DIFF
--- a/scripts/brave_rewards/publisher/youtube/utils.ts
+++ b/scripts/brave_rewards/publisher/youtube/utils.ts
@@ -68,17 +68,6 @@ export const getChannelIdFromUrl = (path: string) => {
   return params[0]
 }
 
-export const getChannelIdFromChannelPage = (scripts: HTMLCollectionOf<HTMLScriptElement>) => {
-  for (const script of scripts) {
-    let match = getChannelIdFromResponse(script.text)
-    if (match) {
-      return match
-    }
-  }
-
-  return ''
-}
-
 export const getChannelIdFromResponse = (data: string) => {
   if (!data) {
     return ''

--- a/scripts/brave_rewards/publisher/youtube/youtube.ts
+++ b/scripts/brave_rewards/publisher/youtube/youtube.ts
@@ -288,8 +288,8 @@ const sendPublisherInfo = () => {
     return
   }
 
-  const channelId = utils.getChannelIdFromChannelPage(document.scripts)
-  sendPublisherInfoForChannel(channelId)
+  // Otherwise, it's a custom url which is handled just like a user url
+  sendPublisherInfoForUser()
 }
 
 const sendMediaDurationMetadata = (url: URL) => {


### PR DESCRIPTION
Resolves https://github.com/brave/brave-browser/issues/12281

## Test Plan:

- Clean profile
- Enable Rewards
- Visit https://www.youtube.com/channel/UCCs7AQEDwrHEc86r0NNXE_A
- Open Rewards Panel and confirm that Lauren Rees is shown
- Click Youtube logo at top of page
- Click on a creator's name that points to a custom URL (you can check if it's a custom URL by hovering over the creator name and looking at the gray status bar in the bottom left of the browser window - if the URL starts like this `https://youtube.com/c/...` it's a custom URL)
- Open Rewards panel and confirm that creator's name is shown and not Lauren Rees