### PR TITLE
Add support for Rewards Vimeo publishers

### DIFF
--- a/Greaselion.json
+++ b/Greaselion.json
@@ -86,6 +86,15 @@
   },
   {
     "urls": [
+      "https://vimeo.com/*"
+    ],
+    "scripts": [
+      "scripts/brave_rewards/publisher/vimeo/vimeoBase.bundle.js"
+    ],
+    "minimum_brave_version": "1.18"
+  },
+  {
+    "urls": [
       "https://m.youtube.com/*",
       "https://www.youtube.com/*"
     ],

--- a/scripts/brave_rewards/publisher/vimeo/publisherInfo.ts
+++ b/scripts/brave_rewards/publisher/vimeo/publisherInfo.ts
@@ -1,0 +1,182 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { port } from '../common/messaging'
+
+import * as types from './types'
+import * as utils from './utils'
+
+const getPublisherData = async () => {
+  if (utils.isVideoPath(location.pathname)) {
+    return getPublisherDataFromVideoPage()
+  } else {
+    return getPublisherDataFromUnrecognizedPage()
+  }
+}
+
+const getPublisherDataFromVideoPage = async () => {
+  const url = location.href
+  const encodedVideoUrl = encodeURI(url)
+
+  const oembedResponse = await fetch(`https://vimeo.com/api/oembed.json?url=${encodedVideoUrl}`)
+  if (!oembedResponse.ok) {
+    return getPublisherDataFromUnrecognizedPage()
+  }
+
+  const data = await oembedResponse.json()
+  if (!data) {
+    return getPublisherDataFromUnrecognizedPage()
+  }
+
+  const publisherUrl = data.author_url
+  if (!publisherUrl) {
+    return getPublisherDataFromUnrecognizedPage()
+  }
+
+  const publisherName = data.author_name
+  if (!publisherName) {
+    throw new Error('Invalid publisher name')
+  }
+
+  const videoId = data.video_id
+  if (!videoId || videoId === 0) {
+    return getPublisherDataFromUnrecognizedPage()
+  }
+
+  const response = await fetch(publisherUrl)
+  if (!response.ok) {
+    throw new Error(`Publisher request failed: ${response.statusText} (${response.status})`)
+  }
+
+  const responseText = await response.text()
+
+  const userId = utils.getUserIdFromPublisherPageResponse(responseText)
+  if (!userId) {
+    throw new Error('Invalid user id')
+  }
+
+  const publisherKey = utils.buildPublisherKey(userId)
+
+  const mediaKey = utils.buildMediaKey(videoId)
+  if (!mediaKey) {
+    throw new Error('Invalid media key')
+  }
+
+  const favIconUrl = utils.buildFavIconUrl(userId)
+
+  return {
+    url: publisherUrl,
+    publisherKey,
+    publisherName,
+    mediaKey,
+    favIconUrl
+  }
+}
+
+const getPublisherDataFromUnrecognizedPage = async () => {
+  const url = location.href
+  const response = await fetch(url)
+  if (!response.ok) {
+    throw new Error(`Publisher request failed: ${response.statusText} (${response.status})`)
+  }
+
+  const responseText = await response.text()
+  if (!responseText) {
+    throw new Error('Publisher response empty')
+  }
+
+  // Determine whether this is a publisher page or a video page
+
+  let publisherName = ''
+  let mediaKey = ''
+
+  let userId = utils.getUserIdFromPublisherPageResponse(responseText)
+  if (userId) {
+    publisherName = utils.getPublisherNameFromPublisherPageResponse(responseText)
+    if (!publisherName) {
+      throw new Error('Invalid publisher name')
+    }
+  } else {
+    publisherName = utils.getPublisherNameFromVideoPageResponse(responseText)
+    if (!publisherName) {
+      throw new Error('Invalid publisher name')
+    }
+
+    userId = utils.getUserIdFromVideoPageResponse(responseText)
+    if (!userId) {
+      throw new Error('Invalid user id')
+    }
+
+    const videoId = utils.getVideoIdFromVideoPageResponse(responseText)
+    if (!videoId) {
+      throw new Error('Invalid video id')
+    }
+
+    mediaKey = utils.buildMediaKey(videoId)
+  }
+
+  const publisherKey = utils.buildPublisherKey(userId)
+
+  return {
+    url,
+    publisherKey,
+    publisherName,
+    mediaKey,
+    favIconUrl: ''
+  }
+}
+
+const sendForStandardPage = () => {
+  getPublisherData()
+    .then((publisherData) => {
+      if (!port) {
+        throw new Error('Invalid port')
+      }
+      port.postMessage({
+        type: 'SavePublisherVisit',
+        mediaType: types.mediaType,
+        data: {
+          url: publisherData.url,
+          publisherKey: publisherData.publisherKey,
+          publisherName: publisherData.publisherName,
+          mediaKey: publisherData.mediaKey,
+          favIconUrl: publisherData.favIconUrl
+        }
+      })
+    })
+    .catch((error) => {
+      throw new Error(`Failed to retrieve publisher data: ${error}`)
+    })
+}
+
+const sendForExcludedPage = () => {
+  const url = `https://${types.mediaDomain}`
+  const publisherKey = types.mediaDomain
+  const publisherName = types.mediaDomain
+  const favIconUrl = ''
+
+  if (!port) {
+    return
+  }
+
+  port.postMessage({
+    type: 'SavePublisherVisit',
+    mediaType: '',
+    data: {
+      url: url,
+      publisherKey,
+      publisherName,
+      favIconUrl
+    }
+  })
+}
+
+export const send = () => {
+  const url = new URL(location.href)
+  if (utils.isExcludedPath(url.pathname)) {
+    sendForExcludedPage()
+  } else {
+    sendForStandardPage()
+  }
+}

--- a/scripts/brave_rewards/publisher/vimeo/types.ts
+++ b/scripts/brave_rewards/publisher/vimeo/types.ts
@@ -1,0 +1,6 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+export const mediaType = 'vimeo'
+export const mediaDomain = 'vimeo.com'

--- a/scripts/brave_rewards/publisher/vimeo/utils.test.ts
+++ b/scripts/brave_rewards/publisher/vimeo/utils.test.ts
@@ -1,0 +1,26 @@
+import * as utils from './utils'
+
+test('builds media key', () => {
+  expect(utils.buildMediaKey('40638487')).toBe('vimeo_40638487')
+})
+
+test('builds publisher key', () => {
+  expect(utils.buildPublisherKey('3425620')).toBe('vimeo#channel:3425620')
+})
+
+test('builds favicon url', () => {
+  expect(utils.buildFavIconUrl('40638487'))
+    .toBe('https://i.vimeocdn.com/portrait/40638487_300x300.webp')
+})
+
+test('builds video url', () => {
+  expect(utils.buildVideoUrl('40638487')).toBe('https://vimeo.com/40638487')
+})
+
+test('ia allowed event', () => {
+  expect(utils.isAllowedEvent('video-start-time')).toBe(true)
+})
+
+test('is disallowed event', () => {
+  expect(utils.isAllowedEvent('video-foo')).toBe(false)
+})

--- a/scripts/brave_rewards/publisher/vimeo/utils.ts
+++ b/scripts/brave_rewards/publisher/vimeo/utils.ts
@@ -1,0 +1,176 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import * as types from './types'
+import * as utils from '../common/utils'
+
+export const buildMediaKey = (mediaId: string) => {
+  return `${types.mediaType}_${mediaId}`
+}
+
+export const buildPublisherKey = (key: string) => {
+  return `${types.mediaType}#channel:${key}`
+}
+
+export const buildFavIconUrl = (userId: string) => {
+  if (!userId) {
+    return ''
+  }
+
+  return `https://i.vimeocdn.com/portrait/${userId}_300x300.webp`
+}
+
+export const buildVideoUrl = (mediaId: string) => {
+  if (!mediaId) {
+    return ''
+  }
+
+  return `https://vimeo.com/${mediaId}`
+}
+
+export const getPublisherNameFromPublisherPageResponse = (response: string) => {
+  if (!response) {
+    return ''
+  }
+
+  const publisherName = getPublisherNameFromVideoPageResponse(response)
+  if (!publisherName) {
+    return utils.extractData(response, '<meta property="og:title" content="', '"')
+  }
+
+  return publisherName
+}
+
+export const getPublisherNameFromVideoPageResponse = (response: string) => {
+  if (!response) {
+    return ''
+  }
+
+  const publisherNameJson = utils.extractData(response, '"display_name":"', '"')
+  if (!publisherNameJson) {
+    return ''
+  }
+
+  let object = null
+  try {
+    object = JSON.parse(`{"brave_publisher":"${publisherNameJson}"}`)
+  } catch (error) {
+    throw new Error(`Error parsing publisher name from video page response: ${error}`)
+  }
+
+  return object.brave_publisher
+}
+
+export const getUserIdFromPublisherPageResponse = (response: string) => {
+  if (!response) {
+    return ''
+  }
+
+  const userId = utils.extractData(response, '<meta property="al:ios:url" content="vimeo://app.vimeo.com/users/', '"')
+  if (userId) {
+    return userId
+  }
+
+  return utils.extractData(response, '<meta property="al:android:url" content="vimeo://app.vimeo.com/users/', '"')
+}
+
+export const getUserIdFromVideoPageResponse = (response: string) => {
+  if (!response) {
+    return ''
+  }
+
+  return utils.extractData(response, '"creator_id":', ',')
+}
+
+export const getVideoIdFromVideoPageResponse = (response: string) => {
+  if (!response) {
+    return ''
+  }
+
+  return utils.extractData(response, '<link rel="canonical" href="https://vimeo.com/', '"')
+}
+
+export const isAllowedEvent = (event: string) => {
+  if (!event) {
+    return false
+  }
+
+  const events = [
+    'video-start-time',
+    'video-minute-watched',
+    'video-paused',
+    'video-played',
+    'video-seek',
+    'video-seeked'
+  ]
+
+  if (events.includes(event)) {
+    return true
+  }
+
+  return false
+}
+
+export const isVideoPath = (path: string) => {
+  if (path && /^\/\d+$/.test(path)) {
+    return true
+  }
+
+  return false
+}
+
+export const isExcludedPath = (path: string) => {
+  if (!path) {
+    return false
+  }
+
+  const paths = [
+    '/',
+    '/about',
+    '/blog',
+    '/enterprise',
+    '/help',
+    '/jobs',
+    '/live',
+    '/log_in',
+    '/ondemand',
+    '/ott',
+    '/purchases',
+    '/search',
+    '/settings',
+    '/site_map',
+    '/stats',
+    '/stock',
+    '/upgrade',
+    '/upload',
+    '/videoschool',
+    '/watch',
+    '/watchlater'
+  ]
+
+  if (paths.includes(path) || paths.includes(path + '/')) {
+    return true
+  }
+
+  const startPatterns = [
+    '/blog/',
+    '/categories/',
+    '/channels/',
+    '/features/',
+    '/help/',
+    '/manage/',
+    '/ott/',
+    '/settings/',
+    '/solutions/',
+    '/stock/'
+  ]
+
+  for (const pattern of startPatterns) {
+    if (path.startsWith(pattern)) {
+      return true
+    }
+  }
+
+  return false
+}

--- a/scripts/brave_rewards/publisher/vimeo/utils.ts
+++ b/scripts/brave_rewards/publisher/vimeo/utils.ts
@@ -153,6 +153,12 @@ export const isExcludedPath = (path: string) => {
     return true
   }
 
+  // In general, we block urls that start with '/channels/' but let
+  // this one through
+  if (path.startsWith('/channels/staffpicks/')) {
+    return false
+  }
+
   const startPatterns = [
     '/blog/',
     '/categories/',

--- a/scripts/brave_rewards/publisher/vimeo/vimeoBase.ts
+++ b/scripts/brave_rewards/publisher/vimeo/vimeoBase.ts
@@ -5,6 +5,25 @@
 import { createPort } from '../common/messaging'
 
 import * as publisherInfo from './publisherInfo'
+import * as tabHandlers from '../common/tabHandlers'
+import * as types from './types'
+
+let lastLocation = ''
+
+const handleOnUpdatedTab = (changeInfo: any) => {
+  // When sites use the history API, it can cause spurious
+  // tabs.onUpdated notifications. In order to work around that, look
+  // for a changeInfo with a URL or a status of complete and then
+  // store the location if it doesn't match.
+  if (!changeInfo || (!changeInfo.url && changeInfo.status !== 'complete')) {
+    return
+  }
+
+  if (location.href !== lastLocation) {
+    lastLocation = location.href
+    publisherInfo.send()
+  }
+}
 
 const initScript = () => {
   // Don't run in incognito context
@@ -14,8 +33,7 @@ const initScript = () => {
 
   createPort()
 
-  // Load publisher info and register webRequest.OnCompleted handler
-  // when document finishes loading
+  // Send publisher info when document finishes loading
   document.addEventListener('readystatechange', function () {
     if (document.readyState === 'complete' &&
         document.visibilityState === 'visible') {
@@ -25,13 +43,14 @@ const initScript = () => {
     }
   })
 
-  // Load publisher info and register webRequest.OnCompleted handler
-  // on visibility change
+  // Send publisher info on visibility change
   document.addEventListener('visibilitychange', function () {
     if (document.visibilityState === 'visible') {
       publisherInfo.send()
     }
   })
+
+  tabHandlers.registerOnUpdatedTab(types.mediaType, handleOnUpdatedTab)
 
   console.info('Greaselion script loaded: vimeo.ts')
 }

--- a/scripts/brave_rewards/publisher/vimeo/vimeoBase.ts
+++ b/scripts/brave_rewards/publisher/vimeo/vimeoBase.ts
@@ -1,0 +1,39 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { createPort } from '../common/messaging'
+
+import * as publisherInfo from './publisherInfo'
+
+const initScript = () => {
+  // Don't run in incognito context
+  if (chrome.extension.inIncognitoContext) {
+    return
+  }
+
+  createPort()
+
+  // Load publisher info and register webRequest.OnCompleted handler
+  // when document finishes loading
+  document.addEventListener('readystatechange', function () {
+    if (document.readyState === 'complete' &&
+        document.visibilityState === 'visible') {
+      setTimeout(() => {
+        publisherInfo.send()
+      }, 200)
+    }
+  })
+
+  // Load publisher info and register webRequest.OnCompleted handler
+  // on visibility change
+  document.addEventListener('visibilitychange', function () {
+    if (document.visibilityState === 'visible') {
+      publisherInfo.send()
+    }
+  })
+
+  console.info('Greaselion script loaded: vimeo.ts')
+}
+
+initScript()

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -19,6 +19,7 @@ module.exports = (env, argv) => {
       ['scripts/brave_rewards/publisher/reddit/redditInlineTipping']: './scripts/brave_rewards/publisher/reddit/redditInlineTipping',
       ['scripts/brave_rewards/publisher/twitter/twitterBase']: './scripts/brave_rewards/publisher/twitter/twitterBase',
       ['scripts/brave_rewards/publisher/twitter/twitterInlineTipping']: './scripts/brave_rewards/publisher/twitter/twitterInlineTipping',
+      ['scripts/brave_rewards/publisher/vimeo/vimeoBase']: './scripts/brave_rewards/publisher/vimeo/vimeoBase',
       ['scripts/brave_rewards/publisher/youtube/youtubeBase']: './scripts/brave_rewards/publisher/youtube/youtubeBase'
     },
     plugins: [


### PR DESCRIPTION
Associated brave-core PR: https://github.com/brave/brave-core/pull/6955

Adds support for Vimeo-based publisher tips via a Greaselion script. The script reacts to URL navigations and state changes by sending the associated publisher info to the Rewards extension, allowing tips to be supported via the Rewards panel.