### PR TITLE
Rewards scripts will now communicate with the Brave extension

### DIFF
--- a/scripts/brave_rewards/publisher/common/messaging.ts
+++ b/scripts/brave_rewards/publisher/common/messaging.ts
@@ -4,14 +4,42 @@
 
 import * as types from './types'
 
-export let port: chrome.runtime.Port | null = null
+let port: chrome.runtime.Port | null = null
 
-export const createPort = () => {
+export const getPort = () => {
+  return port
+}
+
+export const createPort = (callback: (success: boolean) => void) => {
   if (port) {
+    callback(true)
     return
   }
 
-  port = chrome.runtime.connect(types.braveRewardsExtensionId, { name: 'Greaselion' })
+  // The Rewards Greaselion API lives in the Brave extension now, but
+  // previously it lived in the Rewards extension. To support
+  // backwards compatibility with older browsers, send a special
+  // message to the Brave extension. If we get the expected response,
+  // then connect to the Brave extension. Otherwise, if we timeout
+  // connect to the Rewards extension instead.
+  chrome.runtime.sendMessage(
+    types.braveExtensionId,
+    { type: 'SupportsGreaselion' },
+    function (response) {
+      if (!chrome.runtime.lastError && response && response.supported) {
+        port = chrome.runtime.connect(types.braveExtensionId, { name: 'Greaselion' })
+        callback(true)
+        return
+      }
+    })
+
+  setTimeout(() => {
+    if (!port) {
+      port = chrome.runtime.connect(types.braveRewardsExtensionId, { name: 'Greaselion' })
+      callback(true)
+      return
+    }
+  }, 100)
 }
 
 export const sendErrorResponse = (mediaType: string, errorMessage: string) => {

--- a/scripts/brave_rewards/publisher/common/tabHandlers.ts
+++ b/scripts/brave_rewards/publisher/common/tabHandlers.ts
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { port } from '../common/messaging'
+import { getPort } from '../common/messaging'
 
 let registeredOnUpdatedTab = false
 
@@ -13,6 +13,7 @@ export const registerOnUpdatedTab = (mediaType: string, callback: (changeInfo: a
 
   registeredOnUpdatedTab = true
 
+  const port = getPort()
   if (!port) {
     return
   }

--- a/scripts/brave_rewards/publisher/common/types.ts
+++ b/scripts/brave_rewards/publisher/common/types.ts
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+export const braveExtensionId = 'mnojpmjdmbbfmejpflffifhffcmidifd'
 export const braveRewardsExtensionId = 'jidkidbbcafjabdphckchenhfomhnfma'
 
 export interface MediaMetaData {

--- a/scripts/brave_rewards/publisher/common/utils.ts
+++ b/scripts/brave_rewards/publisher/common/utils.ts
@@ -49,3 +49,7 @@ export const areObjectsEqualShallow = (firstObj: {}, secondObj: {}) => {
 
   return true
 }
+
+export const documentReady = () => {
+  return document.readyState === 'complete' && document.visibilityState === 'visible'
+}

--- a/scripts/brave_rewards/publisher/common/webRequestHandlers.ts
+++ b/scripts/brave_rewards/publisher/common/webRequestHandlers.ts
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { port } from '../common/messaging'
+import { getPort } from '../common/messaging'
 
 let registeredOnCompletedWebRequestHandler = false
 let registeredOnSendHeadersWebRequest = false
@@ -14,6 +14,7 @@ export const registerOnCompletedWebRequestHandler = (mediaType: string, urlPatte
 
   registeredOnCompletedWebRequestHandler = true
 
+  const port = getPort()
   if (!port) {
     return
   }
@@ -43,6 +44,7 @@ export const registerOnSendHeadersWebRequest = (mediaType: string, urlPatterns: 
 
   registeredOnSendHeadersWebRequest = true
 
+  const port = getPort()
   if (!port) {
     return
   }

--- a/scripts/brave_rewards/publisher/github/githubInlineTipping.ts
+++ b/scripts/brave_rewards/publisher/github/githubInlineTipping.ts
@@ -7,6 +7,7 @@ import { createPort } from '../common/messaging'
 import * as tabHandlers from '../common/tabHandlers'
 import * as tipping from './tipping'
 import * as types from './types'
+import * as utils from '../common/utils'
 
 let lastLocation = ''
 
@@ -31,16 +32,32 @@ const initScript = () => {
     return
   }
 
-  createPort()
-
-  // Configure tip action on visibility change
-  document.addEventListener('visibilitychange', function () {
-    if (document.visibilityState === 'visible') {
-      tipping.configure()
+  createPort((success: boolean) => {
+    if (!success) {
+      console.error('Failed to initialize communications port')
+      return
     }
-  })
 
-  tabHandlers.registerOnUpdatedTab(types.mediaType, handleOnUpdatedTab)
+    // Configure tip action on readystate change
+    if (utils.documentReady()) {
+      tipping.configure()
+    } else {
+      document.addEventListener('readystatechange', function () {
+        if (utils.documentReady()) {
+          tipping.configure()
+        }
+      })
+    }
+
+    // Configure tip action on visibility change
+    document.addEventListener('visibilitychange', function () {
+      if (document.visibilityState === 'visible') {
+        tipping.configure()
+      }
+    })
+
+    tabHandlers.registerOnUpdatedTab(types.mediaType, handleOnUpdatedTab)
+  })
 
   console.info('Greaselion script loaded: githubInlineTipping.ts')
 }

--- a/scripts/brave_rewards/publisher/github/publisherInfo.ts
+++ b/scripts/brave_rewards/publisher/github/publisherInfo.ts
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { port, sendErrorResponse } from '../common/messaging'
+import { getPort, sendErrorResponse } from '../common/messaging'
 import { MediaMetaData } from '../common/types'
 
 import * as types from './types'
@@ -15,6 +15,7 @@ const sendForExcludedPage = () => {
   const mediaKey = ''
   const favIconUrl = ''
 
+  const port = getPort()
   if (!port) {
     return
   }
@@ -54,6 +55,7 @@ const sendForStandardPage = (url: URL) => {
 
       const profileUrl = utils.buildProfileUrl(screenName)
 
+      const port = getPort()
       if (!port) {
         return
       }

--- a/scripts/brave_rewards/publisher/github/tipping.ts
+++ b/scripts/brave_rewards/publisher/github/tipping.ts
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { port } from '../common/messaging'
+import { getPort } from '../common/messaging'
 import { MediaMetaData } from '../common/types'
 
 import * as locale from '../common/locale'
@@ -25,6 +25,7 @@ const tipUser = (mediaMetaData: MediaMetaData) => {
   const publisherName = mediaMetaData.user.fullName
   const publisherScreenName = mediaMetaData.user.screenName
 
+  const port = getPort()
   if (!port) {
     return
   }

--- a/scripts/brave_rewards/publisher/reddit/publisherInfo.ts
+++ b/scripts/brave_rewards/publisher/reddit/publisherInfo.ts
@@ -3,7 +3,7 @@
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { MediaMetaData } from '../common/types'
-import { port, sendErrorResponse } from '../common/messaging'
+import { getPort, sendErrorResponse } from '../common/messaging'
 
 import * as types from './types'
 import * as utils from './utils'
@@ -105,6 +105,7 @@ const sendForStandardPage = (url: URL) => {
       // so pass false here
       const profileUrl = utils.buildProfileUrl(screenName, false)
 
+      const port = getPort()
       if (!port) {
         return
       }
@@ -130,6 +131,7 @@ const sendForExcludedPage = () => {
   const mediaKey = ''
   const favIconUrl = ''
 
+  const port = getPort()
   if (!port) {
     return
   }

--- a/scripts/brave_rewards/publisher/reddit/redditBase.ts
+++ b/scripts/brave_rewards/publisher/reddit/redditBase.ts
@@ -7,6 +7,7 @@ import { createPort } from '../common/messaging'
 import * as publisherInfo from './publisherInfo'
 import * as tabHandlers from '../common/tabHandlers'
 import * as types from './types'
+import * as utils from '../common/utils'
 
 let lastLocation = ''
 
@@ -31,24 +32,32 @@ const initScript = () => {
     return
   }
 
-  createPort()
-
-  // Configure tip action on visibility change
-  document.addEventListener('readystatechange', function () {
-    if (document.readyState === 'complete' &&
-        document.visibilityState === 'visible') {
-      publisherInfo.send()
+  createPort((success: boolean) => {
+    if (!success) {
+      console.error('Failed to initialize communications port')
+      return
     }
-  })
 
-  // Send publisher info on visibility change
-  document.addEventListener('visibilitychange', function () {
-    if (document.visibilityState === 'visible') {
+    // Send publisher info on readystate change
+    if (utils.documentReady()) {
       publisherInfo.send()
+    } else {
+      document.addEventListener('readystatechange', function () {
+        if (utils.documentReady()) {
+          publisherInfo.send()
+        }
+      })
     }
-  })
 
-  tabHandlers.registerOnUpdatedTab(types.mediaType, handleOnUpdatedTab)
+    // Send publisher info on visibility change
+    document.addEventListener('visibilitychange', function () {
+      if (document.visibilityState === 'visible') {
+        publisherInfo.send()
+      }
+    })
+
+    tabHandlers.registerOnUpdatedTab(types.mediaType, handleOnUpdatedTab)
+  })
 
   console.info('Greaselion script loaded: redditBase.ts')
 }

--- a/scripts/brave_rewards/publisher/reddit/tipping.ts
+++ b/scripts/brave_rewards/publisher/reddit/tipping.ts
@@ -3,7 +3,7 @@
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { MediaMetaData } from '../common/types'
-import { port } from '../common/messaging'
+import { getPort } from '../common/messaging'
 
 import * as locale from '../common/locale'
 import * as types from './types'
@@ -456,6 +456,7 @@ const configureForOldReddit = (postType: string) => {
 }
 
 const tipUser = (mediaMetaData: MediaMetaData) => {
+  const port = getPort()
   if (!port) {
     return
   }

--- a/scripts/brave_rewards/publisher/twitter/api.ts
+++ b/scripts/brave_rewards/publisher/twitter/api.ts
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { port } from '../common/messaging'
+import { getPort } from '../common/messaging'
 import { getAuthHeaders } from './auth'
 
 import * as types from './types'
@@ -20,6 +20,7 @@ const sendAPIRequest = (name: string, url: string) => {
       return
     }
 
+    const port = getPort()
     if (!port) {
       reject(new Error('Invalid port'))
       return

--- a/scripts/brave_rewards/publisher/twitter/publisherInfo.ts
+++ b/scripts/brave_rewards/publisher/twitter/publisherInfo.ts
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { port } from '../common/messaging'
+import { getPort } from '../common/messaging'
 
 import * as api from './api'
 import * as types from './types'
@@ -15,6 +15,7 @@ const sendForExcludedPage = () => {
   const mediaKey = ''
   const favIconUrl = ''
 
+  const port = getPort()
   if (!port) {
     return
   }
@@ -48,6 +49,7 @@ const sendForStandardPage = (url: URL) => {
 
        const profileUrl = utils.buildProfileUrl(screenName, userId)
 
+       const port = getPort()
        if (!port) {
          return
        }

--- a/scripts/brave_rewards/publisher/twitter/tipping.ts
+++ b/scripts/brave_rewards/publisher/twitter/tipping.ts
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { port } from '../common/messaging'
+import { getPort } from '../common/messaging'
 import { MediaMetaData } from '../common/types'
 
 import * as api from './api'
@@ -228,6 +228,7 @@ const tipUser = (mediaMetaData: MediaMetaData) => {
   const publisherName = mediaMetaData.user.screenName
   const publisherScreenName = mediaMetaData.user.screenName
 
+  const port = getPort()
   if (!port) {
     return
   }

--- a/scripts/brave_rewards/publisher/twitter/twitterBase.ts
+++ b/scripts/brave_rewards/publisher/twitter/twitterBase.ts
@@ -4,12 +4,12 @@
 
 import { createPort } from '../common/messaging'
 
-import * as tabHandlers from '../common/tabHandlers'
-import * as webRequestHandlers from '../common/webRequestHandlers'
-
 import * as auth from './auth'
 import * as publisherInfo from './publisherInfo'
+import * as tabHandlers from '../common/tabHandlers'
 import * as types from './types'
+import * as utils from '../common/utils'
+import * as webRequestHandlers from '../common/webRequestHandlers'
 
 const handleOnSendHeadersWebRequest = (mediaType: string, details: any) => {
   if (mediaType !== types.mediaType || !details || !details.requestHeaders) {
@@ -35,21 +35,37 @@ const initScript = () => {
     return
   }
 
-  createPort()
-
-  // Send publisher info on visibility change
-  document.addEventListener('visibilitychange', function () {
-    if (document.visibilityState === 'visible') {
-      publisherInfo.send()
+  createPort((success: boolean) => {
+    if (!success) {
+      console.error('Failed to initialize communications port')
+      return
     }
-  })
 
-  webRequestHandlers.registerOnSendHeadersWebRequest(
-    types.mediaType,
-    types.sendHeadersUrls,
-    types.sendHeadersExtra,
-    handleOnSendHeadersWebRequest)
-  tabHandlers.registerOnUpdatedTab(types.mediaType, handleOnUpdatedTab)
+    // Send publisher info on readystate change
+    if (utils.documentReady()) {
+      publisherInfo.send()
+    } else {
+      document.addEventListener('readystatechange', function () {
+        if (utils.documentReady()) {
+          publisherInfo.send()
+        }
+      })
+    }
+
+    // Send publisher info on visibility change
+    document.addEventListener('visibilitychange', function () {
+      if (document.visibilityState === 'visible') {
+        publisherInfo.send()
+      }
+    })
+
+    webRequestHandlers.registerOnSendHeadersWebRequest(
+      types.mediaType,
+      types.sendHeadersUrls,
+      types.sendHeadersExtra,
+      handleOnSendHeadersWebRequest)
+    tabHandlers.registerOnUpdatedTab(types.mediaType, handleOnUpdatedTab)
+  })
 
   console.info('Greaselion script loaded: twitterBase.ts')
 }

--- a/scripts/brave_rewards/publisher/vimeo/publisherInfo.ts
+++ b/scripts/brave_rewards/publisher/vimeo/publisherInfo.ts
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { port } from '../common/messaging'
+import { getPort } from '../common/messaging'
 
 import * as types from './types'
 import * as utils from './utils'
@@ -130,6 +130,7 @@ const getPublisherDataFromUnrecognizedPage = async () => {
 const sendForStandardPage = () => {
   getPublisherData()
     .then((publisherData) => {
+      const port = getPort()
       if (!port) {
         throw new Error('Invalid port')
       }
@@ -156,6 +157,7 @@ const sendForExcludedPage = () => {
   const publisherName = types.mediaDomain
   const favIconUrl = ''
 
+  const port = getPort()
   if (!port) {
     return
   }

--- a/scripts/brave_rewards/publisher/vimeo/vimeoBase.ts
+++ b/scripts/brave_rewards/publisher/vimeo/vimeoBase.ts
@@ -7,6 +7,7 @@ import { createPort } from '../common/messaging'
 import * as publisherInfo from './publisherInfo'
 import * as tabHandlers from '../common/tabHandlers'
 import * as types from './types'
+import * as utils from '../common/utils'
 
 let lastLocation = ''
 
@@ -31,26 +32,34 @@ const initScript = () => {
     return
   }
 
-  createPort()
-
-  // Send publisher info when document finishes loading
-  document.addEventListener('readystatechange', function () {
-    if (document.readyState === 'complete' &&
-        document.visibilityState === 'visible') {
-      setTimeout(() => {
-        publisherInfo.send()
-      }, 200)
+  createPort((success: boolean) => {
+    if (!success) {
+      console.error('Failed to initialize communications port')
+      return
     }
-  })
 
-  // Send publisher info on visibility change
-  document.addEventListener('visibilitychange', function () {
-    if (document.visibilityState === 'visible') {
+    // Send publisher info when document finishes loading
+    if (utils.documentReady()) {
       publisherInfo.send()
+    } else {
+      document.addEventListener('readystatechange', function () {
+        if (utils.documentReady()) {
+          setTimeout(() => {
+            publisherInfo.send()
+          }, 200)
+        }
+      })
     }
-  })
 
-  tabHandlers.registerOnUpdatedTab(types.mediaType, handleOnUpdatedTab)
+    // Send publisher info on visibility change
+    document.addEventListener('visibilitychange', function () {
+      if (document.visibilityState === 'visible') {
+        publisherInfo.send()
+      }
+    })
+
+    tabHandlers.registerOnUpdatedTab(types.mediaType, handleOnUpdatedTab)
+  })
 
   console.info('Greaselion script loaded: vimeo.ts')
 }

--- a/scripts/brave_rewards/publisher/youtube/mediaDuration.ts
+++ b/scripts/brave_rewards/publisher/youtube/mediaDuration.ts
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { port } from '../common/messaging'
+import { getPort } from '../common/messaging'
 
 import * as types from './types'
 import * as utils from './utils'
@@ -20,6 +20,7 @@ export const sendMetadata = (url: URL) => {
   const mediaKey = utils.buildMediaKey(mediaId)
   const duration = utils.getMediaDurationFromParts(searchParams)
 
+  const port = getPort()
   if (!port) {
     return
   }

--- a/scripts/brave_rewards/publisher/youtube/publisherInfo.ts
+++ b/scripts/brave_rewards/publisher/youtube/publisherInfo.ts
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { port, sendErrorResponse } from '../common/messaging'
+import { getPort, sendErrorResponse } from '../common/messaging'
 
 import * as types from './types'
 import * as utils from './utils'
@@ -37,6 +37,7 @@ const sendForChannel = (channelId: string) => {
   const publisherUrl = utils.buildChannelUrl(channelId)
   const favIconUrl = utils.getFavIconUrlFromPage(document.scripts)
 
+  const port = getPort()
   if (!port) {
     return
   }
@@ -60,6 +61,7 @@ const sendForExcluded = () => {
   const publisherName = types.mediaDomain
   const favIconUrl = ''
 
+  const port = getPort()
   if (!port) {
     return
   }
@@ -111,6 +113,7 @@ const sendForUser = () => {
       const favIconUrl = utils.getFavIconUrlFromResponse(responseText)
       const publisherUrl = utils.buildChannelUrl(channelId)
 
+      const port = getPort()
       if (!port) {
         return
       }
@@ -163,6 +166,7 @@ const sendForVideoHelper = (url: string, responseText: string, publisherName: st
 
   const favIconUrl = utils.getFavIconUrlFromResponse(responseText)
 
+  const port = getPort()
   if (!port) {
     return
   }


### PR DESCRIPTION
As part of https://github.com/brave/brave-browser/issues/12307, the Rewards Greaselion scripts must now communicate with the Brave extension rather than the Rewards extension.