### PR TITLE
Base vimeo support should target Brave 1.18, not 1.19

### DIFF
--- a/Greaselion.json
+++ b/Greaselion.json
@@ -155,7 +155,7 @@
     "scripts": [
       "scripts/brave_rewards/publisher/vimeo/vimeoBase.bundle.js"
     ],
-    "minimum_brave_version": "1.19"
+    "minimum_brave_version": "1.18"
   },
   {
     "urls": [


### PR DESCRIPTION
Resolves https://github.com/brave/brave-browser/issues/12968

When we added auto-contribution support to Greaselion in https://github.com/brave/brave-browser/issues/12107 (targeting Brave 1.19), base Vimeo support was also accidentally changed to target Brave 1.19. That was a mistake and it should target Brave 1.18 and above as originally planned.