### PR TITLE
Greaselion makes excessive calls to Twitter API

### DIFF
--- a/scripts/brave_rewards/publisher/common/lruCache.ts
+++ b/scripts/brave_rewards/publisher/common/lruCache.ts
@@ -1,0 +1,38 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+export class LruCache<T> {
+
+  private values: Map<string, T> = new Map<string, T>()
+  private maxEntries: number
+
+  constructor (maxEntries: number) {
+    this.maxEntries = maxEntries
+  }
+
+  get (key: string): T | null {
+    if (!key) {
+      return null
+    }
+
+    const entry = this.values.get(key)
+    if (!entry) {
+      return null
+    }
+
+    this.values.delete(key)
+    this.values.set(key, entry)
+
+    return entry
+  }
+
+  put (key: string, value: T) {
+    if (this.values.size >= this.maxEntries) {
+      const key = this.values.keys().next().value
+      this.values.delete(key)
+    }
+
+    this.values.set(key, value)
+  }
+}

--- a/scripts/brave_rewards/publisher/twitter/auth.ts
+++ b/scripts/brave_rewards/publisher/twitter/auth.ts
@@ -63,6 +63,11 @@ export const processRequestHeaders = (requestHeaders: any[]) => {
     }
   }
 
+  // For our purposes (authentication), we want this always to be 'yes'
+  if (headers['x-twitter-active-user'] !== 'yes') {
+    headers['x-twitter-active-user'] = 'yes'
+  }
+
   if (commonUtils.areObjectsEqualShallow(authHeaders, headers)) {
     return false
   }

--- a/scripts/brave_rewards/publisher/twitter/auth.ts
+++ b/scripts/brave_rewards/publisher/twitter/auth.ts
@@ -35,6 +35,11 @@ export const getAuthHeaders = () => {
   return authHeaders
 }
 
+export const hasRequiredAuthHeaders = () => {
+  return authHeaders['authorization'] &&
+         (authHeaders['x-csrf-token'] || authHeaders['x-guest-token'])
+}
+
 export const processRequestHeaders = (requestHeaders: any[]) => {
   if (!requestHeaders) {
     return false


### PR DESCRIPTION
Resolves https://github.com/brave/brave-browser/issues/13578

### Description

Limit the number of calls we make to the Twitter API to avoid rate limiting. In addition, cache fetched publisher info in a small LRU cache to avoid making unnecessary calls in the first place.

### Test Plan

- Clean profile
- Launch Twitter
- Visit various Twitter users using multiple tabs, switching tabs, scrolling, etc.
- Ensure that we don't call `https://api.twitter.com/1.1/users/show.json?screen_name={$user}` more than once every 3 seconds
