### PR TITLE
Fix Twitter auth headers

### DIFF
--- a/scripts/brave_rewards/publisher/twitter/auth.ts
+++ b/scripts/brave_rewards/publisher/twitter/auth.ts
@@ -37,7 +37,8 @@ export const getAuthHeaders = () => {
 
 export const hasRequiredAuthHeaders = () => {
   return authHeaders['authorization'] &&
-         (authHeaders['x-csrf-token'] || authHeaders['x-guest-token'])
+         ((authHeaders['x-csrf-token'] && authHeaders['x-twitter-auth-type']) ||
+          (authHeaders['x-csrf-token'] && authHeaders['x-guest-token']))
 }
 
 export const processRequestHeaders = (requestHeaders: any[]) => {


### PR DESCRIPTION
Follow-up to https://github.com/brave/brave-site-specific-scripts/pull/40

After testing, @jonathansampson saw that he was still receiving a 429 error in one scenario. We theorized that Twitter is sending an incorrect HTTP status for a more general error related to incorrect auth headers. We modified our function to ensure that we have appropriate auth headers when logged in or visiting Twitter as a guest.