### PR TITLE
Position Tip button correctly next to More Info element

### DIFF
--- a/scripts/brave_rewards/publisher/reddit/tipping.ts
+++ b/scripts/brave_rewards/publisher/reddit/tipping.ts
@@ -433,17 +433,12 @@ const configureForMoreInfoElement = (
   lastElement: Element,
   config: any
 ) => {
-  if (!element || !lastElement || !config) {
+  if (!element || !lastElement || !lastElement.parentElement || !config) {
     return
   }
 
-  if (!config.usersPost) {
-    lastElement.insertAdjacentElement(
-      'beforebegin', createElementTipAction(element, config.posts))
-  } else if (lastElement.parentElement && config.usersPost) {
-    lastElement.parentElement.insertAdjacentElement(
-      'beforebegin', createElementTipAction(element, config.posts))
-  }
+  lastElement.parentElement.insertAdjacentElement(
+    'beforebegin', createElementTipAction(element, config.posts))
 }
 
 const configureForPosts = (config: any) => {


### PR DESCRIPTION
Fixes https://github.com/brave/brave-browser/issues/15287.

Positions the Rewards "Tip" button correctly when next to a "More Info" element.