### PR TITLE
Fix injection of Tip button for starred items tab in Github

### DIFF
--- a/scripts/brave_rewards/publisher/github/tipping.ts
+++ b/scripts/brave_rewards/publisher/github/tipping.ts
@@ -62,7 +62,7 @@ const createTipAction = (
 
   const tipActionHoverText = locale.getMessage('githubTipsHoverText')
   if (tipActionHoverText) {
-    tipAction.className += ' tooltipped tooltipped-sw tooltipped-align-right-1'
+    tipAction.className += ' tooltipped tooltipped-sw'
     tipAction.setAttribute('aria-label', tipActionHoverText)
   }
 
@@ -291,7 +291,7 @@ const starringContainerInsertFunction = (parent: Element) => {
     return
   }
 
-  if (utils.isBlocklistedTab(window.location.search)) {
+  if (!utils.isAllowedTab(window.location.search)) {
     return
   }
 

--- a/scripts/brave_rewards/publisher/github/utils.test.ts
+++ b/scripts/brave_rewards/publisher/github/utils.test.ts
@@ -35,10 +35,18 @@ test('path is not excluded', () => {
   expect(utils.isExcludedPath('/foo')).toBe(false)
 })
 
-test('tab is in blocklist', () => {
-  expect(utils.isBlocklistedTab('?tab=repositories')).toBe(true)
+test('tab is not allowed (empty querystring)', () => {
+  expect(utils.isAllowedTab('')).toBe(false)
 })
 
-test('tab is not in blocklist', () => {
-  expect(utils.isBlocklistedTab('?tab=stars')).toBe(false)
+test('tab is not allowed (no tab specifier in querystring)', () => {
+  expect(utils.isAllowedTab('?foo=bar')).toBe(false)
+})
+
+test('tab is not allowed (no entry in allowlist)', () => {
+  expect(utils.isAllowedTab('?tab=repositories')).toBe(false)
+})
+
+test('tab is allowed', () => {
+  expect(utils.isAllowedTab('?tab=stars')).toBe(true)
 })

--- a/scripts/brave_rewards/publisher/github/utils.ts
+++ b/scripts/brave_rewards/publisher/github/utils.ts
@@ -66,20 +66,24 @@ export const isExcludedPath = (path: string) => {
   return false
 }
 
-export const isBlocklistedTab = (queryString: string) => {
+export const isAllowedTab = (queryString: string) => {
   if (!queryString) {
     return false
   }
 
-  const blocklist = [ 'repositories' ]
+  const allowlist = [ 'stars' ]
 
-  const match = queryString.match('[?|&]tab=([^&]+)&?')
-  if (!match || match.length < 2 || !match[1]) {
+  const searchParams = new URLSearchParams(queryString)
+  if (!searchParams || !searchParams.has('tab')) {
     return false
   }
 
-  const tab = match[1]
-  if (!blocklist.includes(tab)) {
+  const tabName = searchParams.get('tab')
+  if (!tabName) {
+    return false
+  }
+
+  if (!allowlist.includes(tabName)) {
     return false
   }
 


### PR DESCRIPTION
Resolves https://github.com/brave/brave-browser/issues/15432

Fix injection of Tip button for starred items in Github. The injection criteria were too wide, resulting in the Tip button being injected into the user's profile page.