### PR TITLE
Use userId if unable to parse publisher name from Vimeo response data

### DIFF
--- a/scripts/brave_rewards/publisher/vimeo/publisherInfo.ts
+++ b/scripts/brave_rewards/publisher/vimeo/publisherInfo.ts
@@ -96,7 +96,9 @@ const getPublisherInfoForUnrecognizedPage = async () => {
     publisherName =
       utils.getPublisherNameFromPublisherPageResponse(responseText)
     if (!publisherName) {
-      throw new Error('Invalid publisher name')
+      // If we can't parse the publisher name from the page response, use the
+      // userId instead
+      publisherName = userId
     }
   } else {
     publisherName = utils.getPublisherNameFromVideoPageResponse(responseText)

--- a/scripts/brave_rewards/publisher/vimeo/utils.ts
+++ b/scripts/brave_rewards/publisher/vimeo/utils.ts
@@ -61,7 +61,7 @@ export const getUserIdFromPublisherPageResponse = (response: string) => {
     return ''
   }
 
-  const userId = utils.extractData(
+  let userId = utils.extractData(
     response,
     '<meta property="al:ios:url" content="vimeo://app.vimeo.com/users/',
     '"')
@@ -69,9 +69,17 @@ export const getUserIdFromPublisherPageResponse = (response: string) => {
     return userId
   }
 
-  return utils.extractData(
+  userId = utils.extractData(
     response,
     '<meta property="al:android:url" content="vimeo://app.vimeo.com/users/',
+    '"')
+  if (userId) {
+    return userId
+  }
+
+  return utils.extractData(
+    response,
+    '<link rel="canonical" href="/',
     '"')
 }
 


### PR DESCRIPTION
Fixes https://github.com/brave/brave-browser/issues/22832

Fixes issue with Rewards panel not showing publisher info for certain Vimeo creators.

## Test plan

- Clean profile
- Enable Rewards
- Visit vimeo.com/bravelaurenwags
- Verify that `Lauren Wagner` or `bravelaurenwags` shows up as the publisher name in the Rewards panel (either one could show up based on various user settings, e.g., if a custom profile url is being used).