### PR TITLE
Decode HTML entities when displaying Vimeo publisher name

### DIFF
--- a/scripts/brave_rewards/publisher/common/utils.ts
+++ b/scripts/brave_rewards/publisher/common/utils.ts
@@ -79,19 +79,7 @@ export const formatNetworkError = (message: string, response: Response) => {
   return `${message}: ${response.statusText} (${response.status})`
 }
 
-const htmlEntities = {
-  '&amp;': '&',
-  '&lt;': '<',
-  '&gt;': '>',
-  '&quot;': '"',
-  '&#39;': "'"
-}
-
-const htmlEntity = /&(?:amp|lt|gt|quot|#(0+)?39);/g
-const hasHTMLEntity = RegExp(htmlEntity.source)
-
 export const decodeHTMLEntities = (input: string) => {
-  return (input && hasHTMLEntity.test(input))
-    ? input.replace(htmlEntity, (e) => (htmlEntities[e] || "'"))
-    : (input || '')
+  const doc = new DOMParser().parseFromString(input, 'text/html')
+  return doc.documentElement.textContent || ''
 }

--- a/scripts/brave_rewards/publisher/vimeo/utils.ts
+++ b/scripts/brave_rewards/publisher/vimeo/utils.ts
@@ -25,15 +25,15 @@ export const getPublisherNameFromPublisherPageResponse = (response: string) => {
     return ''
   }
 
-  const publisherName = getPublisherNameFromVideoPageResponse(response)
+  let publisherName = getPublisherNameFromVideoPageResponse(response)
   if (!publisherName) {
-    return utils.extractData(
+    publisherName = utils.extractData(
       response,
       '<meta property="og:title" content="',
       '"')
   }
 
-  return publisherName
+  return utils.decodeHTMLEntities(publisherName)
 }
 
 export const getPublisherNameFromVideoPageResponse = (response: string) => {
@@ -53,7 +53,7 @@ export const getPublisherNameFromVideoPageResponse = (response: string) => {
     throw new Error(`Error parsing publisher name from video page: ${error}`)
   }
 
-  return object.brave_publisher
+  return utils.decodeHTMLEntities(object.brave_publisher)
 }
 
 export const getUserIdFromPublisherPageResponse = (response: string) => {


### PR DESCRIPTION
Resolves https://github.com/brave/brave-browser/issues/21062

Decode HTML entities when displaying Vimeo publisher names in the Rewards panel. Approach is based on https://stackoverflow.com/questions/1912501/unescape-html-entities-in-javascript/34064434#34064434 which allows decoding more entities while not introducing XSS vulnerabilities.

