### PR TITLE
Remove inline tips hover text

### DIFF
--- a/scripts/brave_rewards/publisher/github/_locales/en_US/messages.json
+++ b/scripts/brave_rewards/publisher/github/_locales/en_US/messages.json
@@ -1,8 +1,4 @@
 {
-  "githubTipsHoverText": {
-    "message": "Send a tip",
-    "description": "Hover text for tip button"
-  },
   "githubTipsIconLabel": {
     "message": "Tip",
     "description": "Icon label for tip button"

--- a/scripts/brave_rewards/publisher/github/tipping.ts
+++ b/scripts/brave_rewards/publisher/github/tipping.ts
@@ -59,12 +59,6 @@ const createTipAction = (
   tipAction.style.display = 'inline-block'
   tipAction.style.minWidth = '40px'
 
-  const tipActionHoverText = chrome.i18n.getMessage('githubTipsHoverText')
-  if (tipActionHoverText) {
-    tipAction.className += ' tooltipped tooltipped-sw'
-    tipAction.setAttribute('aria-label', tipActionHoverText)
-  }
-
   // Create the tip button
   const tipButton = document.createElement('button')
   tipButton.className =

--- a/scripts/brave_rewards/publisher/reddit/_locales/en_US/messages.json
+++ b/scripts/brave_rewards/publisher/reddit/_locales/en_US/messages.json
@@ -1,8 +1,4 @@
 {
-  "redditTipsHoverText": {
-    "message": "Tip this post",
-    "description": "Hover text for tip button"
-  },
   "redditTipsIconLabel": {
     "message": "Tip",
     "description": "Icon label for tip button"

--- a/scripts/brave_rewards/publisher/reddit/tipping.ts
+++ b/scripts/brave_rewards/publisher/reddit/tipping.ts
@@ -207,10 +207,6 @@ const createTipAction = (isPost: boolean) => {
     tipAction.style.alignItems = 'center'
   }
 
-  tipAction.setAttribute(
-    'data-original-title',
-    chrome.i18n.getMessage('redditTipsHoverText'))
-
   return tipAction
 }
 

--- a/scripts/brave_rewards/publisher/twitter/_locales/en_US/messages.json
+++ b/scripts/brave_rewards/publisher/twitter/_locales/en_US/messages.json
@@ -1,8 +1,4 @@
 {
-  "twitterTipsHoverText": {
-    "message": "Tip this tweet",
-    "description": "Hover text for tip button"
-  },
   "twitterTipsIconLabel": {
     "message": "Tip",
     "description": "Icon label for tip button"

--- a/scripts/brave_rewards/publisher/twitter/tipping.ts
+++ b/scripts/brave_rewards/publisher/twitter/tipping.ts
@@ -111,9 +111,6 @@ const createTipAction = (
   tipAction.style.textAlign = hasUserActions ? 'right' : 'start'
   tipAction.setAttribute('role', 'button')
   tipAction.setAttribute('tabindex', '0')
-  tipAction.setAttribute(
-    'data-original-title',
-    chrome.i18n.getMessage('twitterTipsHoverText'))
   tipAction.addEventListener('keydown', onTipActionKey)
 
   // Create the tip button


### PR DESCRIPTION
Resolves https://github.com/brave/brave-browser/issues/28699

Remove inline tips hover text.

QA note: In my testing, it seemed like the hover text for Twitter and Reddit was non-functional even before this change, probably due to underlying DOM changes.