### PR TITLE
Remove Twitter inline tip buttons

### DIFF
--- a/Greaselion.json
+++ b/Greaselion.json
@@ -127,20 +127,6 @@
       "https://*.twitter.com/*"
     ],
     "scripts": [
-      "scripts/brave_rewards/publisher/twitter/twitterInlineTipping.bundle.js"
-    ],
-    "preconditions": {
-      "twitter-tips-enabled": true
-    },
-    "messages": "scripts/brave_rewards/publisher/twitter/_locales",
-    "minimum_brave_version": "1.17"
-  },
-  {
-    "urls": [
-      "https://twitter.com/*",
-      "https://*.twitter.com/*"
-    ],
-    "scripts": [
       "scripts/brave_rewards/publisher/twitter/twitterAutoContribution.bundle.js"
     ],
     "preconditions": {


### PR DESCRIPTION
Resolves https://github.com/brave/brave-browser/issues/32107

For now, we will just remove the Twitter inline tips script from the `Greaselion.json` file.